### PR TITLE
Added debug option to see SSO groups at login

### DIFF
--- a/action.php
+++ b/action.php
@@ -78,6 +78,11 @@ class action_plugin_authdiscourse extends DokuWiki_Action_Plugin
 
         $this->setTokenCookie($nonce);
 
+        if ( $this->getConf('debug') ) {
+            msg("AuthDiscourse - SSO Endpoint: " . $endpoint);
+            msg("AuthDiscourse - SSO Request: " . $endpoint . '?' . http_build_query($request));
+        }
+
         send_redirect($endpoint . '?' . http_build_query($request));
     }
 

--- a/auth.php
+++ b/auth.php
@@ -52,6 +52,12 @@ class auth_plugin_authdiscourse extends auth_plugin_authplain
             $token = $ssoResponse['nonce'];
             $groups = !empty($ssoResponse['groups']) ? explode(',', $ssoResponse['groups']) : [];
 
+            if ( $this->getConf('debug')) {
+                foreach ($groups as $ssogroup) {
+                    msg("SSO group: " . $ssogroup);
+                }
+	        }
+
             // user with this email exists? try login
             $found = $this->retrieveUsers(0, 1, ['mail' => '^' . str_replace('.', '\.', $mail) . '$']);
             if ($found) {

--- a/conf/default.php
+++ b/conf/default.php
@@ -7,3 +7,4 @@
 
 $conf['endpoint']       = '';
 $conf['secret']         = '';
+$conf['debug']         = 0;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -7,3 +7,4 @@
 
 $meta['endpoint'] = ['string'];
 $meta['secret'] = ['string'];
+$meta['debug']  = array('onoff','_caution' => 'security');

--- a/lang/de/settings.php
+++ b/lang/de/settings.php
@@ -7,3 +7,4 @@
 
 $lang['url'] = 'URL des Discourse Servers';
 $lang['secret'] = 'SSO provider secret';
+$lang['debug'] = 'Zeige debugging Informationen bei der Anmeldung';

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -7,3 +7,4 @@
 
 $lang['url'] = 'Discourse URL';
 $lang['secret'] = 'SSO provider secret';
+$lang['debug'] = 'Show debugging information at login';


### PR DESCRIPTION
Added a simple debug option to look at the SSO endpoint settings and especially  the groups obtained from Discourse to get the DokuWiki ACLs right.